### PR TITLE
Sharpened Volcano Fragment: afterburn buff & special-ish tweak

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -350,6 +350,14 @@
 			"attrib"		"5 ; 1.2"
 			"tags"			"damage_uber_healers 0.20"
 		}
+		"348"	//Sharpened Volcano Fragment
+		{
+			"class"			"Pyro:Melee"
+			"desp"			"Sharpened Volcano Fragment: {positive}+200% afterburn damage bonus, {negative}minicrits instead of crits"
+			"attrib"		"71 ; 3.0"
+			"minicrit"		"1"
+			"crit"			"0"
+		}
 		
 		// DEMOMAN
 		


### PR DESCRIPTION
- increased afterburn damage by 200% to match flamethrowers
- gives a minicrit buff instead of crit buff when held to increase afterburn damage from flamethrowers and itself

stock Fire Axe > 195 dmg on hit
minicrit SVF with minicrit afterburn > 70 initial dmg + 240 afterburn dmg (310 total)
minicrit SVF with regular afterburn > 70 initial dmg + 180 afterburn dmg (250 total)

this weapon was on 42's "list of useless weapons"