### PR TITLE
Pyro: remove secondary minicrits

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -105,10 +105,6 @@
 				"desp"		"Primary: {positive}3x afterburn dmg, {negative}airblast costs 70 ammo"
 				"attrib"	"71 ; 3.0 ; 170 ; 3.5"
 			}
-			"Secondary"
-			{
-				"minicrit"	"1"
-			}
 			"Melee"
 			{
 				"crit"		"1"


### PR DESCRIPTION
Minicrits on secondary weapons are useless besides boosting afterburn in weapons other than shotguns, which get no use anyway. Afterburn boosting has been moved to Sharpened Volcano Fragment.