### PR TITLE
 Kritzkrieg: remove overheal penalty

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -553,8 +553,6 @@
 		"35"	//Kritzkrieg
 		{
 			"class"			"Medic:Secondary"
-			"desp"			"Kritzkrieg: {negative}50% overheal penalty"
-			"attrib"		"105 ; 0.5"
 			"tags"			"event_cond 11"
 		}
 		"411"	//Quick Fix

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -552,7 +552,6 @@
 		}
 		"35"	//Kritzkrieg
 		{
-			"class"			"Medic:Secondary"
 			"tags"			"event_cond 11"
 		}
 		"411"	//Quick Fix


### PR DESCRIPTION
The overheal penalty was added because patients used to get a defense buff when healed, and that was frustrating to play against alongside crits, but that's gone now.