### PR TITLE
Ambassador Buff

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -675,6 +675,16 @@
 		
 		// SPY
 		
+		"61"	//Ambassador
+		{
+			"class"			"Spy:Primary"
+			"desp"			"Ambassador: {positive}Critical damage is no longer affected by range"
+			"attrib"		"868 ; 0"
+		}
+		"1006"	//Festive Ambassador
+		{
+			"prefab"		"61
+		}	
 		"224"	//L'Etranger
 		{
 			"class"			"Spy:Primary"

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -683,7 +683,7 @@
 		}
 		"1006"	//Festive Ambassador
 		{
-			"prefab"		"61
+			"prefab"		"61"
 		}	
 		"224"	//L'Etranger
 		{


### PR DESCRIPTION
Ambassador
Because it's probably the most dogshit weapon spy has right now in vsh because of the Jungle Inferno nerfs.
Weapon Index: 61 (1006 for festive)

Removing this attribute: 868 | Critical damage is affected by range.
Actually makes this weapon more of a competitive option with this gone, though it still might need another buff later.