### PR TITLE
Homewrecker: Add knockback, less damage/firing speed

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -361,6 +361,16 @@
 			"minicrit"		"1"
 			"crit"			"0"
 		}
+		"153"	//Homewrecker
+		{
+			"class"			"Pyro:Melee"
+			"desp"			"Homewrecker: {positive}Slight knockback on hit, {negative}-90% damage vs players, 50% slower firing speed"
+			"attrib"		"791 ; 1.5 ; 138 ; 0.1 ; 5 ; 0.5"
+		}
+		"466"	//Maul
+		{
+			"prefab"		"153"
+		}
 		
 		// DEMOMAN
 		

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -365,7 +365,7 @@
 		{
 			"class"			"Pyro:Melee"
 			"desp"			"Homewrecker: {positive}Slight knockback on hit, {negative}-90% damage vs players, 50% slower firing speed"
-			"attrib"		"791 ; 1.5 ; 138 ; 0.1 ; 5 ; 0.5"
+			"attrib"		"791 ; 1.5 ; 138 ; 0.1 ; 5 ; 1.5"
 		}
 		"466"	//Maul
 		{


### PR DESCRIPTION
The weapon has no use and 42 allowed me to do this anyway. It deals 20 damage, it pushes the boss off like a shortstop shove. Note that `+damage vs buldings` and `removes sappers on hit` attributes are still there