### PR TITLE
better description consistency/wording

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -76,7 +76,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Scout: {negative}No double jump when only 3 players are alive"
+				"desp"		"Scout: {negative}No double jump when 3 or less players are alive"
 			}
 			"Secondary"
 			{
@@ -167,7 +167,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}2x bodyshot damage, boss glows on hit"
+				"desp"		"Primary: {positive}+100% bodyshot damage, adds an outline to the boss on hit"
 				"tags"		"damage_bodyshot_multiplier 2.0 ; damage_glow 4.0"
 			}
 			"Secondary"
@@ -193,7 +193,7 @@
 			}
 			"Melee"
 			{
-				"desp"		"Melee: {neutral}Backstabs deal ~7% of boss health"
+				"desp"		"Melee: {neutral}Backstabs deal ~7% of the boss's health"
 				"tags"		"damage_backstab_player 70 ; damage_backstab_min 450 ; damage_backstab_max 1500"
 			}
 			"PDA2"
@@ -209,7 +209,7 @@
 		"357"	//Half-Zatoichi
 		{
 			"class"			"Soldier:Melee ; Demoman:Melee"
-			"desp"			"Half-Zatoichi: {positive}+100hp on hit"
+			"desp"			"Half-Zatoichi: {positive}Gain 100 health on hit"
 			"attrib"		"16 ; 100.0"
 		}
 		
@@ -228,7 +228,7 @@
 		"772"	//Baby Face Blaster
 		{
 			"class"			"Scout:Primary"
-			"desp"			"Baby Face Blaster: {negative}75% less boost on hit, boost is reset on rage"
+			"desp"			"Baby Face Blaster: {negative}Boost charges 75% slower, boost is reset on rage"
 			"attrib"		"418 ; 0.0"
 			"tags"			"damage_event_scale 0.25"
 		}
@@ -257,7 +257,7 @@
 		"237"	//Rocket Jumper
 		{
 			"class"			"Soldier:Primary"
-			"desp"			"Rocket Jumper: {negative}Replaced with Rocket Launcher"
+			"desp"			"Rocket Jumper: {neutral}Replaced with Rocket Launcher"
 			"restricted"	"1"
 		}
 		"414"	//Liberty Launcher
@@ -269,7 +269,7 @@
 		"730"	//The Beggar's Bazooka
 		{
 			"class"			"Soldier:Primary"
-			"desp"			"Beggar's Bazooka: {positive}Removed radius penalty"
+			"desp"			"Beggar's Bazooka: {positive}Removed explosion radius penalty"
 			"attrib"		"100 ; 1.0"
 		}
 		"129"	//Buff Banner
@@ -291,7 +291,7 @@
 		"226"	//Battalion's Backup
 		{
 			"class"			"Soldier:Secondary"
-			"desp"			"Battalion's Backup: {positive}Spawns up to 5 zombie scouts on use"
+			"desp"			"Battalion's Backup: {positive}Spawns up to 5 zombie Scouts on use"
 			"tags"			"event_zombie_max 5 ; event_zombie_min 2 ; event_reduce_on_use 1"
 		}
 		"354"	//Concheror
@@ -309,14 +309,14 @@
 		"444"	//Mantreads
 		{
 			"class"			"Soldier:Secondary"
-			"desp"			"Mantreads: {positive}-60% blast damage, 500 damage on stomp"
+			"desp"			"Mantreads: {positive}-60% blast damage to self, stomping deals 500 damage"
 			"attrib"		"135 ; 0.4"
 			"tags"			"damage_stomp 500"
 		}
 		"416"	//Market Gardener
 		{
 			"class"			"Soldier:Melee"
-			"desp"			"Market Gardener: {positive}Deals ~5% of boss health when airborne, {negative}no crits"
+			"desp"			"Market Gardener: {positive}Airborne hits deal ~5% of the boss's health, {negative}no crits"
 			"tags"			"damage_airborne_player 50 ; damage_airborne_min 300 ; damage_airborne_max 1000"
 			"minicrit"		"0"
 			"crit"			"0"
@@ -337,13 +337,13 @@
 		"1179"	//Thermal Thruster
 		{
 			"class"			"Pyro:Secondary"
-			"desp"			"Thermal Thruster: {positive}1024 damage on stomp"
+			"desp"			"Thermal Thruster: {positive}Stomping deals 1024 damage"
 			"tags"			"damage_stomp 1024"
 		}
 		"1180"	//Gas Passer
 		{
 			"class"			"Pyro:Secondary"
-			"desp"			"Gas Passer: {positive}Explode on ignite, {negative}2x slower recharge"
+			"desp"			"Gas Passer: {positive}Boss explodes when ignited, {negative}100% slower charge rate"
 			"attrib"		"874 ; 2.0 ; 875 ; 1.0"
 		}
 		"593"	//Third Degree
@@ -383,7 +383,7 @@
 		"405"	//Ali Baba's Wee Booties
 		{
 			"class"			"Demoman:Primary"
-			"desp"			"Ali Baba's Wee Booties: {positive}1024 damage on stomp"
+			"desp"			"Ali Baba's Wee Booties: {positive}Allows stomping for 1024 damage"
 			"attrib"		"259 ; 1.0"
 			"tags"			"damage_stomp 1024"
 		}
@@ -394,13 +394,13 @@
 		"265"	//Sticky Jumper
 		{
 			"class"			"Demoman:Secondary"
-			"desp"			"Sticky Jumper: {negative}Replaced with Stickybomb Launcher"
+			"desp"			"Sticky Jumper: {neutral}Replaced with Stickybomb Launcher"
 			"restricted"	"1"
 		}
 		"131"	//Chargin' Targe
 		{
 			"class"			"Demoman:Secondary"
-			"desp"			"Shield: {positive}Survive an extra hit from the boss and minicrits"
+			"desp"			"Shield: {positive}First melee hit taken from the boss deals no damage, primary weapon receives minicrits"
 			"tags"			"damage_shield 1"
 		}
 		"1144"	//Festive Chargin' Targe
@@ -435,14 +435,14 @@
 		"307"	//Ullapool Caber
 		{
 			"class"			"Demoman:Melee"
-			"desp"			"Ullapool Caber: {positive}2x explosion damage, {negative}marked-for-death while active"
+			"desp"			"Ullapool Caber: {positive}100% explosion damage bonus, {negative}marked-for-death while active"
 			"attrib"		"414 ; 1.0"
 			"tags"			"damage_explosion_multiplier 2.0"
 		}
 		"327"	//Claidheamh Mòr
 		{
 			"class"			"Demoman:Melee"
-			"desp"			"Claidheamh Mòr: {positive}Melee hits refill 25% of your charge meter"
+			"desp"			"Claidheamh Mòr: {positive}Refills 25% of your charge meter on hit"
 		}
 		
 		// HEAVY
@@ -501,7 +501,7 @@
 		"656"	//Holiday Punch
 		{
 			"class"			"Heavy:Melee"
-			"desp"			"Holiday Punch: {negative}Replaced with Fists"
+			"desp"			"Holiday Punch: {neutral}Replaced with Fists"
 			"restricted"	"1"
 		}
 		
@@ -526,13 +526,13 @@
 		"997"	//Rescue Ranger
 		{
 			"class"			"Engineer:Primary"
-			"desp"			"Rescue Ranger: {positive}Bolt deals explosive damage"
+			"desp"			"Rescue Ranger: {positive}Bolts explode on impact"
 			"tags"			"projectile_explosion 45.0"
 		}
 		"528"	//Short Circuit
 		{
 			"class"			"Engineer:Secondary"
-			"desp"			"Short Circuit: {positive}Ball removes rage"
+			"desp"			"Short Circuit: {positive}Alt-fire drains rage on hit"
 			"tags"			"damage_rage_shock -100"
 		}
 		
@@ -570,7 +570,7 @@
 		"35"	//Kritzkrieg
 		{
 			"class"			"Medic:Secondary"
-			"desp"			"Kritzkrieg: {positive}Defense buff to self on use"
+			"desp"			"Kritzkrieg: {positive}ÜberCharge also applies a defense buff to self"
 			"tags"			"event_cond_aoe 11 ; event_cond_add 42"
 		}
 		"411"	//Quick Fix
@@ -605,7 +605,7 @@
 		"56"	//Huntsman
 		{
 			"class"			"Sniper:Primary"
-			"desp"			"Huntsman: {positive}Arrow deals explosion damage"
+			"desp"			"Huntsman: {positive}Arrows explode on inpact"
 			"tags"			"projectile_explosion 45.0 ; damage_glow 0.0"
 			"crit"			"1"
 		}
@@ -652,7 +652,7 @@
 		"57"	//Razorback
 		{
 			"class"			"Sniper:Secondary"
-			"desp"			"Razorback: {positive}Survive an extra hit from the boss"
+			"desp"			"Razorback: {positive}First melee hit taken from the boss deals no damage"
 			"attrib"		"52 ; 0.0 ; 800 ; 1.0"
 			"tags"			"damage_shield 1"
 		}
@@ -710,7 +710,7 @@
 		"810"	//Red-Tape Recorder
 		{
 			"class"			"Spy:Secondary"
-			"desp"			"Red-Tape Recorder: {negative}Replaced with Sapper"
+			"desp"			"Red-Tape Recorder: {neutral}Replaced with Sapper"
 			"restricted"	"1"
 		}
 		"831"	//Red-Tape Recorder (Genuine)
@@ -720,7 +720,7 @@
 		"225"	//Your Eternal Reward
 		{
 			"class"			"Spy:Melee"
-			"desp"			"Your Eternal Reward: {positive}4th backstab deals 6x extra damage, {negative}first 3 backstabs deal 0 damage"
+			"desp"			"Your Eternal Reward: {positive}4th and consecutive backstabs deal +500% damage, {negative}first 3 backstabs deal 0 damage"
 			"tags"			"damage_backstab_chain 4 ; damage_backstab_player 420 ; damage_backstab_max -1"
 		}
 		"574"	//Wanga Prick
@@ -742,7 +742,7 @@
 		"60"	//Cloak and Dagger
 		{
 			"class"			"Spy:Secondary"
-			"desp"			"Cloak and Dagger: {negative}Replaced with Invis Watch"
+			"desp"			"Cloak and Dagger: {neutral}Replaced with Invis Watch"
 			"restricted"	"1"
 		}
 	}

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -605,7 +605,7 @@
 		"56"	//Huntsman
 		{
 			"class"			"Sniper:Primary"
-			"desp"			"Huntsman: {positive}Arrows explode on inpact"
+			"desp"			"Huntsman: {positive}Arrows explode on impact"
 			"tags"			"projectile_explosion 45.0 ; damage_glow 0.0"
 			"crit"			"1"
 		}


### PR DESCRIPTION
- replaces all mentions of 2x/3x/etc to +100%/+200%/etc
- weapon replacements are now neutral instead of negative
- shifts wording around for some stats
- makes a few stats clearer

note that mantreads & thermal thruster are worded in a way that implies they can stomp by default, while demoboots are worded in a way that implies a custom attribute was given to them.