### PR TITLE
Soda Popper: slower hype charge rate

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -238,7 +238,7 @@
         	{
             		"class"            	"Scout:Primary"
             		"desp"         	   	"Soda Popper: {negative}Hype charges ~60% slower"
-           		"attrib"        	"418 ; 0.0"
+           		"attrib"        	"793 ; 0.0"
            		"tags"            	"damage_event_scale 0.167"
       		}
 		"44"	//Sandman

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -234,6 +234,13 @@
 			"attrib"		"418 ; 0.0"
 			"tags"			"damage_event_scale 0.25"
 		}
+		"448"    //Soda Popper
+        	{
+            		"class"            	"Scout:Primary"
+            		"desp"         	   	"Baby Face Blaster: {negative}Hype charges ~60% slower"
+           		"attrib"        	"418 ; 0.0"
+           		"tags"            	"damage_event_scale 0.167"
+      		}
 		"44"	//Sandman
 		{
 			"class"			"Scout:Melee"

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -237,7 +237,7 @@
 		"448"    //Soda Popper
         	{
             		"class"            	"Scout:Primary"
-            		"desp"         	   	"Baby Face Blaster: {negative}Hype charges ~60% slower"
+            		"desp"         	   	"Soda Popper: {negative}Hype charges ~60% slower"
            		"attrib"        	"418 ; 0.0"
            		"tags"            	"damage_event_scale 0.167"
       		}


### PR DESCRIPTION
42 knows why this is being done, playstyle around new dome damage to bosses ends up getting them killed a lot with this weapon, etc. This change makes the Soda Popper take 600 damage to fully charge up.