### PR TITLE
Soda Popper: revert charge rate nerf, lastman crits -> minicrits

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -237,8 +237,8 @@
 		"448"    //Soda Popper
         	{
             		"class"            	"Scout:Primary"
-            		"desp"         	   	"Soda Popper: {negative}Hype charge is reduced when taking damage"
-           		"attrib"        	"733 ; 6.0"
+            		"desp"         	   	"Soda Popper: {negative}Last man standing crits become minicrits"
+           		"crit"			"0"
       		}
 		"44"	//Sandman
 		{

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -237,9 +237,8 @@
 		"448"    //Soda Popper
         	{
             		"class"            	"Scout:Primary"
-            		"desp"         	   	"Soda Popper: {negative}Hype charges ~60% slower"
-           		"attrib"        	"793 ; 0.0"
-           		"tags"            	"damage_event_scale 0.167"
+            		"desp"         	   	"Soda Popper: {negative}Hype charge is reduced when taking damage"
+           		"attrib"        	"733 ; 6.0"
       		}
 		"44"	//Sandman
 		{


### PR DESCRIPTION
The `damage_event_scale` works when Hype is active, so Scouts are able to build Hype when they shouldn't. This removes the tag and adds the `Boost is reduced when hit` attribute to avoid Scouts baiting bosses out of the dome then easily jumping back in. Rate of boost lost is 6% per 1 damage (as opposed to 4% per 1 damage from the BFB, as it's very slightly harder to build, but can't really be abused this way). 

The attribute seems to work with dome damage, but only when Hype is inactive.

--

everything above is obsolete, the change is now to make last man crits into minicrits.