### PR TITLE
Eviction Notice: no move speed bonus, better jump height when active

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -491,8 +491,8 @@
 		"426"	//Eviction Notice
 		{
 			"class"			"Heavy:Melee"
-			"desp"			"Eviction Notice: {positive}Removed damage penalty"
-			"attrib"		"1 ; 1.0"
+			"desp"			"Eviction Notice: {neutral}Active movement speed bonus is replaced with 50% greater jump height"
+			"attrib"		"524 ; 1.5 ; 851 ; 1.0"
 		}
 		"656"	//Holiday Punch
 		{


### PR DESCRIPTION
Since the Eviction Notice is just a worse GRU with combat stats that don't synergize well at all, making it a jump-based mobility weapon instead would make it stand out as a viable option a little bit better. It already had a no dmg penalty custom attribute, but I haven't seen it being used at all anyway.