### PR TITLE
Loose Cannon: last man crits -> minicrits

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -376,6 +376,12 @@
 			"desp"			"Loch-n-load: {positive}+30% damage bonus"
 			"attrib"		"2 ; 1.30"
 		}
+		"996"	//Loose Cannon
+		{
+			"class"			"Demoman:Primary"
+			"desp"			"Loose Cannon: {negative}Last man standing crits become minicrits"
+			"crit"			"0"
+		}
 		"405"	//Ali Baba's Wee Booties
 		{
 			"class"			"Demoman:Primary"


### PR DESCRIPTION
This change is done to reduce knockback done when being the last player alive, mainly because it's annoying to fight against when paired with the Eyelander's speed buff.