### PR TITLE
Demoman: enable full knockback on Secondary weapons

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -119,6 +119,10 @@
 				"desp"		"Primary: {positive}Minicrits airborne targets"
 				"attrib"	"114 ; 1.0"
 			}
+			"Secondary"
+			{
+				"tags"		"damage_knockback ; 1"
+			}
 			"Melee"
 			{
 				"crit"		"1"


### PR DESCRIPTION
This is a buff to Stickybomb Launchers so they may see more play, instead of demo/hybridknights all the time.