### PR TITLE
Scottish Resistance: disable all knockback

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -387,6 +387,12 @@
 		{
 			"prefab"		"405"
 		}
+		"130"	//Scottish Resistance
+		{
+			"class"			"Demoman:Secondary"
+			"desp"			"Scottish Resistance: {negative}No knockback"
+			"tags"			"damage_knockback ; 0"
+		}
 		"265"	//Sticky Jumper
 		{
 			"class"			"Demoman:Secondary"


### PR DESCRIPTION
This is the sticky launcher that sees the most play, it's fine as is, so no (or slight I guess) change is needed.