### PR TITLE
Razorback: mention overheal penalty removal

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -599,7 +599,7 @@
 		}
 		"57"	//Razorback
 		{
-			"desp"			"Razorback: {positive}First melee hit taken from the boss deals no damage"
+			"desp"			"Razorback: {positive}First melee hit taken from the boss deals no damage, no self overheal penalty"
 			"attrib"		"52 ; 0.0 ; 800 ; 1.0"
 			"tags"			"damage_shield ; 1"
 		}


### PR DESCRIPTION
It's just text explaining that there's no overheal penalty, as some other items do this as well.