### PR TITLE
Quickiebomb Launcher: instant det, -4 max stickies

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -376,6 +376,11 @@
 			"desp"			"Scottish Resistance: {negative}No knockback"
 			"tags"			"damage_knockback ; 0"
 		}
+		"1150"	//Quickiebomb Launcher
+		{
+			"desp"			"Quickiebomb Launcher: {positive}Can detonate stickies instantly, {negative}-4 stickies allowed at once"
+			"attrib"		"126 ; -1.0 ; 89 ; -4.0"
+		}
 		"265"	//Sticky Jumper
 		{
 			"desp"			"Sticky Jumper: {neutral}Replaced with Stickybomb Launcher"


### PR DESCRIPTION
Right now, the quickie launcher has very little difference than the stock sticky launcher, this change promotes a more unique playstyle, making it less about building stickytraps and more about hit-and-run, because you can jump away almost as soon as you fire. Just holding down m2 won't work, people are going to kill themselves that way - so at least a bit of thinking is needed to make use of the instant detonation time.