### PR TITLE
Enforcer: crits while disguised, no minicrits while undisguised, crit damage is affected by range

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -657,7 +657,7 @@
 		"460"	//Enforcer
 		{
 			"desp"			"Enforcer: {positive}Receive crits while disguised, {negative}critical damage is affected by range, no minicrits"
-			"attrib"		"868 ; 1"
+			"attrib"		"868 ; 1.0"
 			"tags"			"disguise_cond_add ; 11"
 		}
 		"810"	//Red-Tape Recorder

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -654,6 +654,12 @@
 			"desp"			"Diamondback: {positive}Backstabs gives +2 crits"
 			"tags"			"damage_backstab_crit ; 2"
 		}
+		"460"	//Enforcer
+		{
+			"desp"			"Enforcer: {positive}Receive crits while disguised, {negative}critical damage is affected by range, no minicrits"
+			"attrib"		"868 ; 1"
+			"tags"			"disguise_cond_add ; 11"
+		}
 		"810"	//Red-Tape Recorder
 		{
 			"desp"			"Red-Tape Recorder: {neutral}Replaced with Sapper"

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -658,7 +658,8 @@
 		{
 			"desp"			"Enforcer: {positive}Receive crits while disguised, {negative}critical damage is affected by range, no minicrits"
 			"attrib"		"868 ; 1.0"
-			"tags"			"disguise_cond_add ; 11"
+			"tags"			"disguise_cond_add ; 56"
+			"minicrit"		"0"
 		}
 		"810"	//Red-Tape Recorder
 		{


### PR DESCRIPTION
One of the enforcer's positive stats is that it deals +20% damage while disguised, but that's useless when it's minicrit-boosted while undisguised. This change emphasizes the "shoot while disguised" bit, since it's far easier to hit once while disguised than hitting a headshot with the ambassador for example, the crit falloff attribute that was oringinally used by the ambassador was added to this weapon instead.

**This pull request needs a new tag:** the tag should give a condition to the player holding the weapon while disguised (I guess it's more versatile than just a crit boost), I named it `disguise_cond_add` but you can change it to whatever you feel like and that can be corrected later.