### PR TITLE
Syringe Guns: 5% -> 3% über on hit, stock has no reload

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -154,7 +154,7 @@
 		{
 			"Primary"
 			{
-				"attrib"	"17 ; 0.05"
+				"attrib"	"17 ; 0.03"
 				"crit"		"1"
 			}
 			"Secondary"
@@ -508,7 +508,8 @@
 
 		"17"	//Syringe Gun
 		{
-			"desp"			"Syringe Gun: {positive}+5% ÜberCharge on hit"
+			"desp"			"Syringe Gun: {positive}+3% ÜberCharge on hit, no reload necessary"
+			"attrib"		"303 ; -1.0 ; 307 ; 1.0"
 		}
 		"204"	//Syringe Gun (Renamed/Strange)
 		{
@@ -516,7 +517,7 @@
 		}
 		"36"	//Blutsauger
 		{
-			"desp"			"Blutsauger: {positive}+5% ÜberCharge on hit"
+			"desp"			"Blutsauger: {positive}+3% ÜberCharge on hit"
 		}
 		"305"	//Crusader's Crossbow
 		{
@@ -529,7 +530,7 @@
 		}
 		"412"	//Overdose
 		{
-			"desp"			"Overdose: {positive}+5% ÜberCharge on hit"
+			"desp"			"Overdose: {positive}+3% ÜberCharge on hit"
 		}
 		"35"	//Kritzkrieg
 		{


### PR DESCRIPTION
Needleguns are far more chosen than the crossbow because they're great self-defense tools, the Overdose, specifically, is the most chosen out of the three, because its speed bonus is far better utility than, well, nothing. This change makes it so they're still better at self defense than the crossbow, but just not AS good so the crossbow has a chance. The stock needlegun also receives a no reload bonus (attribute 307 is just there to display text when inspecting it, it does nothing) to compete with the Overdose, a change to the Blutsauger to make it more of an offensive weapon is planned, but not very well thought about just yet, maybe later.