### PR TITLE
Demoboots, demoshields and razorback: text changes

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -363,7 +363,7 @@
 		}
 		"405"	//Ali Baba's Wee Booties
 		{
-			"desp"			"Ali Baba's Wee Booties: {positive}Allows stomping for 1024 damage, +10% movement speed"
+			"desp"			"Ali Baba's Wee Booties: {positive}Allows stomping for 1024 damage, movement speed bonus doesn't need a shield"
 			"attrib"		"259 ; 1.0 ; 788 ; 1.0 ; 107 ; 1.1"
 			"tags"			"damage_stomp ; 1024"
 		}
@@ -383,7 +383,7 @@
 		}
 		"131"	//Chargin' Targe
 		{
-			"desp"			"Shield: {positive}First melee hit taken from the boss deals no damage, primary weapon receives minicrits"
+			"desp"			"Shield: {neutral}First melee hit taken destroys it: absorbing all damage and making it unusable, {positive}primary weapon receives minicrits"
 			"tags"			"damage_shield ; 1"
 		}
 		"1144"	//Festive Chargin' Targe
@@ -605,7 +605,7 @@
 		}
 		"57"	//Razorback
 		{
-			"desp"			"Razorback: {positive}First melee hit taken from the boss deals no damage, no self overheal penalty"
+			"desp"			"Razorback: {positive}First melee hit taken absorbs all damage, no self overheal penalty"
 			"attrib"		"52 ; 0.0 ; 800 ; 1.0"
 			"tags"			"damage_shield ; 1"
 		}


### PR DESCRIPTION
Demoboots: mentions that the speed boost is the same, but you don't need a shield to make use of it
Demoshields: since they are unusable after breaking, it should be considered neutral
Razorback: text update to match demoshields, it's still positive as it has no other use