### PR TITLE
Pain Train: +30% health from healers, -50% from hp packs

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -215,12 +215,17 @@
 			"desp"			"Half-Zatoichi: {positive}Gain 100 health on hit"
 			"attrib"		"16 ; 100.0"
 		}
+		"154"	//Pain Train
+		{
+			"desp"			"Pain Train: {positive}+30% health from healers, {negative}-50% health from health packs"
+			"attrib"		"70 ; 1.3 ; 109 ; 0.5 ; 68 ; 0.0 ; 67 ; 1.0"
+		}
 
 		// SCOUT
 
 		"772"	//Baby Face Blaster
 		{
-			"desp"			"Baby Face Blaster: {negative}boost is reset on stun"
+			"desp"			"Baby Face Blaster: {negative}Boost is reset on stun"
 		}
 		"44"	//Sandman
 		{


### PR DESCRIPTION
The pain train has no changes in VSH: Rewrite, so this is a proposed change to make it unique. It's kind of a reverse back scratcher, allowing you to be more safe with a medic, but pretty doomed without one. This does not affect concheror healing.

(this also capitalizes 'boost' in the bfb's description to make it consistent with the rest because it's just below)