### PR TITLE
Homewrecker: slightly increase damage and knockback

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -345,8 +345,8 @@
 		}
 		"153"	//Homewrecker
 		{
-			"desp"			"Homewrecker: {positive}Slight knockback on hit, {negative}-90% damage vs players, 50% slower firing speed"
-			"attrib"		"791 ; 1.5 ; 138 ; 0.1 ; 5 ; 1.5"
+			"desp"			"Homewrecker: {positive}Slight knockback on hit, {negative}-80% damage vs players, 50% slower firing speed"
+			"attrib"		"791 ; 1.5 ; 138 ; 0.2 ; 5 ; 1.5"
 			"tags"			"damage_knockback ; 1"
 		}
 		"466"	//Maul


### PR DESCRIPTION
This just lowers the damage penalty, but knockback is also increased this way. Its force should be between a shortstop shove and an airblast now.