### PR TITLE
Wrap Assassin: update description to mention ball amount instead of clip size

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -247,7 +247,7 @@
 		}
 		"648"	//Wrap Assassin
 		{
-		"desp"				"Wrap Assassin: {positive}+100% clip size"
+		"desp"				"Wrap Assassin: {positive}Can hold up to 2 balls at once"
 		"attrib"			"279 ; 2.0"
 		}
 


### PR DESCRIPTION


Pretty simple, the description wasn't updated when the attribute had to be changed