### PR TITLE
Brass Beast: no knockback

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -461,8 +461,9 @@
 		}
 		"312"	//Brass Beast
 		{
-			"desp"			"Brass Beast: {negative}No faster spin up time effect"
+			"desp"			"Brass Beast: {negative}No spin up time bonus, no knockback"
 			"attrib"		"87 ; 1.0"
+			"tags"			"damage_knockback ; 0"
 		}
 		"424"	//Tomislav
 		{


### PR DESCRIPTION
It's pretty hard for bosses to reach spots that Heavies with both this weapon and Eviction Notice can, mainly because they just get knocked back mid jump. This change is complemented by a future EN nerf.