### PR TITLE
Eviction Notice: permanent 20 health loss when switched to, no health drain over time

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -463,7 +463,7 @@
 		{
 			"desp"			"Brass Beast: {negative}No spin up time bonus, no knockback"
 			"attrib"		"87 ; 1.0"
-			"tags"			"damage_knockback ; 0" 
+			"tags"			"damage_knockback ; 0"
 		}
 		"424"	//Tomislav
 		{

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -461,8 +461,9 @@
 		}
 		"312"	//Brass Beast
 		{
-			"desp"			"Brass Beast: {negative}No faster spin up time effect"
+			"desp"			"Brass Beast: {negative}No spin up time bonus, no knockback"
 			"attrib"		"87 ; 1.0"
+			"tags"			"damage_knockback ; 0" 
 		}
 		"424"	//Tomislav
 		{

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -461,9 +461,8 @@
 		}
 		"312"	//Brass Beast
 		{
-			"desp"			"Brass Beast: {negative}No spin up time bonus, no knockback"
+			"desp"			"Brass Beast: {negative}No faster spin up time effect"
 			"attrib"		"87 ; 1.0"
-			"tags"			"damage_knockback ; 0"
 		}
 		"424"	//Tomislav
 		{
@@ -495,8 +494,8 @@
 		}
 		"426"	//Eviction Notice
 		{
-			"desp"			"Eviction Notice: {neutral}Active movement speed bonus is replaced with 75% greater jump height"
-			"attrib"		"524 ; 1.75 ; 851 ; 1.0"
+			"desp"			"Eviction Notice: {neutral}Active movement speed bonus is replaced with 75% greater jump height, health is permanently lost when switched to instead of draining"
+			"attrib"		"524 ; 1.75 ; 851 ; 1.0 ; 855 ; 0.01"
 		}
 		"656"	//Holiday Punch
 		{


### PR DESCRIPTION
The last change made it a bit too strong when paired with the Brass Beast, while it's really fun to play with, it's not fun to play against, so to keep the mobility, risking your max health for it sounds like a nice idea, you won't basically super jump everywhere with little cost, and if you decide to do it just once, you'll just be a human sentry for the whole game.

note: you actually drain/regen 1 health per 100 seconds, setting it to 0.0 just makes the attribute not work