### PR TITLE
persian persuader: extra mobility edition

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -463,6 +463,11 @@
 		{
 			"prefab"		"132"
 		}
+		"404"	//Persian Persuader
+		{
+			"desp"			"Persian Persuader: {positive}Able to wall climb"
+			"tags"			"climb ; 750.0 ; event_heal ; -20 ; event_block_attack1 ; 2.0"
+		}
 		"307"	//Ullapool Caber
 		{
 			"desp"			"Ullapool Caber: {positive}100% explosion damage bonus, {negative}marked-for-death while active"


### PR DESCRIPTION
give the persian persuader a wallclimb ability, just like sniper's melees.
does -20HP on hit instead of -15, and has a slightly reduced cooldown, from 3.0 to 2.0
both could obviously be increased or reduced further