### PR TITLE
Blutsauger: regen 8 health on hit, can overheal

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -494,7 +494,7 @@
 
 		"41"	//Natascha
 		{
-			"desp"			"Natascha: {positive}8+ health on hit, {negative}removed slowdown effect"
+			"desp"			"Natascha: {positive}+8 health on hit, {negative}removed slowdown effect"
 			"attrib"		"32 ; 0.0 ; 16 ; 8.0"
 		}
 		"312"	//Brass Beast
@@ -582,7 +582,8 @@
 		}
 		"36"	//Blutsauger
 		{
-			"desp"			"Blutsauger: {positive}+3% ÜberCharge on hit"
+			"desp"			"Blutsauger: {positive}+3% ÜberCharge on hit, +8 health on hit"
+			"attrib"		"16 ; 0.0 ; 180 ; 8.0"
 		}
 		"305"	//Crusader's Crossbow
 		{


### PR DESCRIPTION
This is to make the Blutsauger on par with the other syringe guns. A medic would need to hit 5 times (or 6, taking overheal decay into account) from full health to tank a hit from your average boss.

(this also changes the Natascha's description a little bit)