### PR TITLE
Sniper: overhaul!

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -193,16 +193,18 @@
 			"Primary"
 			{
 				"desp"		"Primary: {positive}+100% bodyshot damage, adds an outline to the boss on hit"
-				"tags"		"damage_bodyshot_multiplier ; 2.0 ; damage_glow ; 4.0 ; damage_knockback ; 0"
+				"tags"		"damage_bodyshot_multiplier ; 2.0 ; damage_glow ; 6.0 ; damage_knockback ; 0"
 			}
 			"Secondary"
 			{
+				"desp"		"Secondary: {positive}No reload necessary" 
+				"attrib"	"303 ; -1.0"
 				"crit"		"1"
 			}
 			"Melee"
 			{
 				"desp"		"Melee: {positive}Able to wall climb"
-				"tags"		"climb ; 750.0 ; event_heal ; -15 ; event_block_attack1 ; 3.0"
+				"tags"		"climb ; 750.0 ; event_heal ; -15 ; climb_max ; 1.0"
 				"crit"		"1"
 			}
 		}
@@ -645,23 +647,33 @@
 		}
 		"230"	//Sydney Sleeper
 		{
-			"desp"			"Sydney Sleeper: {negative}Removed Jarate effect"
+			"desp"			"Sydney Sleeper: {negative}Removed Jarate effect, no outline"
 			"attrib"		"175 ; 0.0"
+			"tags"			"damage_glow ; 0.0"
 		}
 		"402"	//Bazaar Bargain
 		{
-			"desp"			"Bazaar Bargain: {positive}+1 head on every headshot"
-			"tags"			"damage_headshot_decap ; 1"
+			"desp"			"Bazaar Bargain: {positive}+1 head on every headshot, {negative}-33% outline duration"
+			"tags"			"damage_headshot_decap ; 1 ; damage_glow ; 4.0"
 		}
 		"752"	//Hitman's Heatmaker
 		{
 			"desp"			"Hitman's Heatmaker: {positive}+12% focus meter on hit"
 			"attrib"		"387 ; 12.0"
 		}
+		"526"	//Machina
+		{
+			"desp"			"Machina: {negative}-33% outline duration"
+			"tags"			"damage_glow ; 4.0"
+		}
+		"30665"	//Shooting Star
+		{
+			"prefab"		"526"
+		}
 		"58"	//Jarate
 		{
 			"desp"			"Jarate: {neutral}Replaces jarate effect into a rage drain"
-			"tags"			"jarate_remove ; 1 ; jarate_rage ; -150"
+			"tags"			"jarate_remove ; 1 ; jarate_rage ; -200"
 		}
 		"1083"	//Festive Jarate
 		{
@@ -679,26 +691,32 @@
 		}
 		"231"	//Darwin's Danger Shield
 		{
-			"desp"			"Darwin's Danger Shield: {positive}75% less fall damage, +300% increased air control"
-			"attrib"		"492 ; 1.0 ; 527 ; 0.0 ; 610 ; 3.0"
-			"tags"			"damage_resistances_fall ; 0.25"
+			"desp"			"Darwin's Danger Shield: {positive}No fall damage"
+			"attrib"		"492 ; 1.0 ; 527 ; 0.0 ; 275 ; 1.0"
+		}
+		"642"	//Cozy Camper
+		{
+			"desp"			"Cozy Camper: {negative}-50% health regen"
+			"attrib"		"57 ; 2.0"
 		}
 		"751"	//Cleaner's Carbine
 		{
-			"desp"			"Cleaner's Carbine: {positive}No cooldown and self damage climb during Crikey effect, {negative}no crits"
+			"desp"			"Cleaner's Carbine: {positive}No self damage and limit from climbing during Crikey effect, {negative}has to reload, minicrits instead of crits"
 			"tags"			"climb_crikey_noevent ; 1"
+			"attrib"		"303 ; 0.0"
 			"crit"			"0"
+			"minicrit"		"1"
 		}
 		"171"	//Tribalman's Shiv
 		{
-			"desp"			"Tribalman's Shiv: {positive}100% less cooldown on climb, {negative}less climb height"
-			"tags"			"climb ; 600.0 ; event_block_attack1 ; 1.5"
+			"desp"			"Tribalman's Shiv: {positive}Able to wall climb twice without touching the ground, 200% increased air control from climbing, {negative}less climb height"
+			"tags"			"climb ; 600.0 ; climb_max ; 2.0 ; event_attrib_melee ; 610, 3.0 ; event_duration ; 3.0"
 		}
 		"232"	//Bushwacka
 		{
-			"desp"			"Bushwacka: {positive}Higher climb height, removed damage vulnerability, {negative}100% extra health cost on climb"
-			"attrib"		"412 ; 1.0"
-			"tags"			"climb ; 950.0 ; event_heal ; -30"
+			"desp"			"Bushwacka: {positive}Higher climb height, removed damage vulnerability, {negative}233% extra health cost on climb, can't be overhealed"
+			"attrib"		"412 ; 1.0 ; 800 ; 0.0"
+			"tags"			"climb ; 950.0 ; event_heal ; -50"
 		}
 
 		// SPY

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -710,7 +710,7 @@
 		"171"	//Tribalman's Shiv
 		{
 			"desp"			"Tribalman's Shiv: {positive}Able to wall climb twice without touching the ground, 200% increased air control from climbing, {negative}less climb height"
-			"tags"			"climb ; 600.0 ; climb_max ; 2.0 ; event_attrib_melee ; 610, 3.0 ; event_duration ; 3.0"
+			"tags"			"climb ; 600.0 ; climb_max ; 2.0 ; event_attrib_melee ; 610, 3.0 ; event_duration ; 1.5"
 		}
 		"232"	//Bushwacka
 		{

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -715,7 +715,7 @@
 		"232"	//Bushwacka
 		{
 			"desp"			"Bushwacka: {positive}Higher climb height, removed damage vulnerability, {negative}233% extra health cost on climb, can't be overhealed"
-			"attrib"		"412 ; 1.0 ; 800 ; 0.0"
+			"attrib"		"128 ; 0.0 ; 412 ; 1.0 ; 800 ; 0.0"
 			"tags"			"climb ; 950.0 ; event_heal ; -50"
 		}
 


### PR DESCRIPTION
This was discussed for a bit, mainly because if you wanted to play this class, you'd need to play around certain weapon sets, rather than choosing for weapons individually. Changes offer multiple playstyles based on standard and aggressive sniper play.

Here's a list of all the changes:

Primary weapons: outline duration increased by 50% by default
Bazaar Bargain: outline duration remains the same
Machina: outline duration remains the same
Sydney Sleeper: no longer adds an outline

SMG: doesn't need to reload
Cleaner's Carbine: minicrits, rather than having no crit effect at all
Jarate: increased rage drain by 33% (from 150 to 200)
Cozy Camper: -50% health regen
Darwin's Danger Shield: removed air control bonus, wearer now takes no fall damage

Melee weapons: climbing no longer has a cooldown, but is limited to 1 wall climb until the player touches the ground
Bushwacka: increased damage taken from climbing by 66% (from 30 to 50), wearer can't be overhealed
Tribalman's Shiv: temporary air control bonus after wall climbing, instead of shorter cooldown, you are allowed to climb up twice without touching the ground
( Shahanshah still does nothing for now PepeHands )