### PR TITLE
Persian Persuader: update wallclimb to use climb_max instead of cooldown

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -480,7 +480,7 @@
 		"404"	//Persian Persuader
 		{
 			"desp"			"Persian Persuader: {positive}Able to wall climb"
-			"tags"			"climb ; 750.0 ; event_heal ; -20 ; event_block_attack1 ; 2.0"
+			"tags"			"climb ; 750.0 ; event_heal ; -20 ; climb_max ; 1.0"
 		}
 		"307"	//Ullapool Caber
 		{


### PR DESCRIPTION
Just to keep it in line with Sniper melee.