### PR TITLE
Bushwacka: remove non-functional attribute

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -714,8 +714,8 @@
 		}
 		"232"	//Bushwacka
 		{
-			"desp"			"Bushwacka: {positive}Higher climb height, removed damage vulnerability, {negative}233% extra health cost on climb, can't be overhealed"
-			"attrib"		"128 ; 0.0 ; 412 ; 1.0 ; 800 ; 0.0"
+			"desp"			"Bushwacka: {positive}Higher climb height, removed damage vulnerability, {negative}233% extra health cost on climb"
+			"attrib"		"412 ; 1.0"
 			"tags"			"climb ; 950.0 ; event_heal ; -50"
 		}
 


### PR DESCRIPTION
Just to avoid confusion for the average player. If it makes it too strong (it probably won't be), we'll think of something later.