### PR TITLE
Darwin's Danger Shield: fix fire damage reduction not being removed

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -692,7 +692,7 @@
 		"231"	//Darwin's Danger Shield
 		{
 			"desp"			"Darwin's Danger Shield: {positive}No fall damage"
-			"attrib"		"492 ; 1.0 ; 527 ; 0.0 ; 275 ; 1.0"
+			"attrib"		"60 ; 1.0 ; 527 ; 0.0 ; 275 ; 1.0"
 		}
 		"642"	//Cozy Camper
 		{


### PR DESCRIPTION
The attribute being used for the config was a `SET BONUS` attribute, so it didn't match the general attribute being used by the weapon.