### PR TITLE
Syringe Gun: 3% -> 5% uber on hit, no additional effects

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -578,8 +578,8 @@
 
 		"17"	//Syringe Gun
 		{
-			"desp"			"Syringe Gun: {positive}+3% ÜberCharge on hit, no reload necessary"
-			"attrib"		"303 ; -1.0 ; 307 ; 1.0"
+			"desp"			"Syringe Gun: {positive}+5% ÜberCharge on hit"
+			"attrib"		"17 ; 0.05"
 		}
 		"204"	//Syringe Gun (Renamed/Strange)
 		{


### PR DESCRIPTION
The stock needlegun isn't as popular as the other three choices, probably because the current `no reload necessary` stat also has the downside of holding less ammo overall. This change just makes it simple and removes everything besides increased über gain.

things to note:
3% per hit = 34 needles for 100%
5% per hit = 20 needles for 100%
blutsauger needs 7/8 hits to tank a hit (can't tell for sure because of decay, and this doesn't account for potential fall damage)
people have been realizing how useful overdose's active speed boost since valve buffed it to 20% max
the crossbow may not be as good as it was in legacy, but it's still decent for dealing damage as is, plus it's not hard to hit the boss from mid-long range with it