### PR TITLE
Medic: 40% -> 15% starting über, no starting über for Vaccinator

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -182,7 +182,7 @@
 			"Secondary"
 			{
 				"desp"		"Secondary: {positive}Patients get minicrits, able to heal buildings and ÜberCharges get an area of range effect"
-				"tags"		"spawn_uber ; 0.40 ; heal_cond_add ; 16 ; heal_building ; 1 ; event_aoe_radius ; 250.0 ; event_aoe_cond ; 5 ; event_duration ; 8.0"
+				"tags"		"spawn_uber ; 0.10 ; heal_cond_add ; 16 ; heal_building ; 1 ; event_aoe_radius ; 250.0 ; event_aoe_cond ; 5 ; event_duration ; 8.0"
 			}
 			"Melee"
 			{
@@ -617,7 +617,7 @@
 		"998"	//Vaccinator
 		{
 			"desp"			"Vaccinator: {positive}Each resistance gets patients the same effect as other Medi Guns, {negative}no area of range effect"
-			"tags"			"uber_cycle_cond ; 57, 56, 32 ; event_aoe_radius ; 0.0 ; event_duration ; 2.5"
+			"tags"			"spawn_uber ; 0.0 ; uber_cycle_cond ; 57, 56, 32 ; event_aoe_radius ; 0.0 ; event_duration ; 2.5"
 		}
 		"173"	//Vita-Saw
 		{

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -182,7 +182,7 @@
 			"Secondary"
 			{
 				"desp"		"Secondary: {positive}Patients get minicrits, able to heal buildings and ÜberCharges get an area of range effect"
-				"tags"		"spawn_uber ; 0.10 ; heal_cond_add ; 16 ; heal_building ; 1 ; event_aoe_radius ; 250.0 ; event_aoe_cond ; 5 ; event_duration ; 8.0"
+				"tags"		"spawn_uber ; 0.15 ; heal_cond_add ; 16 ; heal_building ; 1 ; event_aoe_radius ; 250.0 ; event_aoe_cond ; 5 ; event_duration ; 8.0"
 			}
 			"Melee"
 			{


### PR DESCRIPTION
40% starting über is a feature that was brought from legacy VSH, but über at the time wasn't the best, it has an AOE now. This change gives the boss a bit of time to hunt for medics before über spam, which pretty hard to stop when there's 5 medics. Vaccinator über is completely removed since it's easier to pop anyway.