### PR TITLE
Reword Pyro primary description

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -125,7 +125,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}+200% afterburn damage bonus, {negative}airblast costs 70 ammo"
+				"desp"		"Primary: {positive}+200% afterburn damage bonus, {negative}+250% airblast cost"
 				"attrib"	"71 ; 3.0 ; 170 ; 3.5"
 			}
 			"Melee"


### PR DESCRIPTION
When I changed this a while ago, I forgot the dragon's fury existed, oops. This change makes it dragon's fury-friendly.