### PR TITLE
Beggar's Bazooka: remove its restriction

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -285,11 +285,6 @@
 			"desp"			"Rocket Jumper: {neutral}Replaced with Rocket Launcher"
 			"restricted"	"1"
 		}
-		"730"	//Beggar's Bazooka
-		{
-			"desp"			"Beggar's Bazooka: {neutral}Replaced with Rocket Launcher"
-			"restricted"	"1"
-		}
 		"1104"	//Air Strike
 		{
 			"desp"			"Air Strike: {positive}Every 200 damages gains 1 clip size"


### PR DESCRIPTION
It became restricted because some crash logs mentioned angled rockets, but the same logs showed up later, way after it became restricted. This means it wasn't the reason for crashing and should be re-enabled.