### PR TITLE
Add missing mentions of weapons healing on hit

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -394,7 +394,7 @@
 		}
 		"214"	//Powerjack
 		{
-			"desp"			"Powerjack: Gain 25 health on hit"
+			"desp"			"Powerjack: {positive}Gain 25 health on hit"
 		}
 
 		// DEMOMAN
@@ -532,7 +532,7 @@
 		}
 		"310"	//Warrior's Spirit
 		{
-			"desp"			"Warrior's Spirit: Gain 50 health on hit"
+			"desp"			"Warrior's Spirit: {positive}Gain 50 health on hit"
 		}
 		"656"	//Holiday Punch
 		{

--- a/vsh.cfg
+++ b/vsh.cfg
@@ -392,6 +392,10 @@
 		{
 			"prefab"		"153"
 		}
+		"214"	//Powerjack
+		{
+			"desp"			"Powerjack: Gain 25 health on hit"
+		}
 
 		// DEMOMAN
 
@@ -525,6 +529,10 @@
 		{
 			"desp"			"Eviction Notice: {neutral}Active movement speed bonus is replaced with 75% greater jump height, health is permanently lost when switched to instead of draining"
 			"attrib"		"524 ; 1.75 ; 851 ; 1.0 ; 855 ; 0.01"
+		}
+		"310"	//Warrior's Spirit
+		{
+			"desp"			"Warrior's Spirit: Gain 50 health on hit"
 		}
 		"656"	//Holiday Punch
 		{


### PR DESCRIPTION
The Warrior's Spirit and Powerjack have been healing on hit for a while, but since the change was done to the attribute the weapons have rather than the weapons themselves, they've been forgotten about and are missing descriptions for it. 

Fix for issue #70