### PR TITLE
SMG: remove no-reload attribute

### DIFF
--- a/vsh.cfg
+++ b/vsh.cfg
@@ -194,8 +194,6 @@
 			}
 			"Secondary"
 			{
-				"desp"		"Secondary: {positive}No reload necessary" 
-				"attrib"	"303 ; -1.0"
 				"crit"		"1"
 			}
 			"Melee"
@@ -736,9 +734,8 @@
 		}
 		"751"	//Cleaner's Carbine
 		{
-			"desp"			"Cleaner's Carbine: {positive}No self damage and limit from climbing during Crikey effect, {negative}has to reload, minicrits instead of crits"
+			"desp"			"Cleaner's Carbine: {positive}No self damage and limit from climbing during Crikey effect, {negative}minicrits instead of crits"
 			"tags"			"climb_crikey_noevent ; 1"
-			"attrib"		"303 ; 0.0"
 			"crit"			"0"
 			"minicrit"		"1"
 		}


### PR DESCRIPTION
The attribute is breaking in a way that people only get 1 full mag worth of bullets and can't pick up ammo boxes, plus it doesn't seem to help that much when it works anyway. Maybe something else will be thought of for this little useless weapon at some point.